### PR TITLE
Match the rust version of the CI version of the locale develop env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: rustlang/rust:nightly
+      - image: rust:1.31
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
This is supposed to be done in the environment of stable `rust 1.31`.
However, CI was done in the nightly environment.

I proposal that use `rust 1.31` in CircleCI.